### PR TITLE
add registering shard and xtransfer test

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -73,7 +73,7 @@ parse_params<chain_apis::read_only::get_transaction_id_params, http_params_types
                else {
                   EOS_THROW(chain::invalid_http_request, "Transaction contains invalid or empty action");
                }
-            } 
+            }
          }
          else {
             EOS_THROW(chain::invalid_http_request, "Transaction actions are missing or invalid");
@@ -151,7 +151,10 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RW_CALL_ASYNC(push_transaction, chain_apis::read_write::push_transaction_results, 202, http_params_types::params_required),
       CHAIN_RW_CALL_ASYNC(push_transactions, chain_apis::read_write::push_transactions_results, 202, http_params_types::params_required),
       CHAIN_RW_CALL_ASYNC(send_transaction, chain_apis::read_write::send_transaction_results, 202, http_params_types::params_required),
-      CHAIN_RW_CALL_ASYNC(send_transaction2, chain_apis::read_write::send_transaction_results, 202, http_params_types::params_required)
+      CHAIN_RW_CALL_ASYNC(send_transaction2, chain_apis::read_write::send_transaction_results, 202, http_params_types::params_required),
+
+      // shard related APIs
+      CHAIN_RO_CALL(get_shards, 200, http_params_types::params_required)
    }, appbase::exec_queue::read_only);
 
    // Not safe to run in parallel with read-only transactions

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -484,6 +484,20 @@ public:
 
    void compute_transaction(const compute_transaction_params& params, chain::plugin_interface::next_function<compute_transaction_results> next ) const;
 
+
+   struct get_shards_params {
+      string                  lower_bound;
+      uint32_t                limit = 50;
+      std::optional<uint32_t> time_limit_ms; // defaults to 10ms
+   };
+
+   struct get_shards_results {
+      vector<fc::variant> shards;
+      string              more; ///< fill lower_bound with this value to fetch more rows
+   };
+
+   get_shards_results get_shards( const get_shards_params& params, const fc::time_point& deadline )const;
+
    struct send_read_only_transaction_results {
       chain::transaction_id_type  transaction_id;
       fc::variant                 processed;
@@ -966,3 +980,6 @@ FC_REFLECT( eosio::chain_apis::read_only::compute_transaction_results, (transact
 FC_REFLECT( eosio::chain_apis::read_only::send_read_only_transaction_params, (transaction))
 FC_REFLECT( eosio::chain_apis::read_only::send_read_only_transaction_results, (transaction_id)(processed) )
 FC_REFLECT( eosio::chain_apis::read_only::get_consensus_parameters_results, (chain_config)(wasm_config))
+FC_REFLECT( eosio::chain_apis::read_only::get_shards_params, (lower_bound)(limit)(time_limit_ms) )
+FC_REFLECT( eosio::chain_apis::read_only::get_shards_results, (shards)(more) )
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/auto_bp_peering_test.py ${CMAKE_CURRE
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/auto_bp_peering_test_shape.json ${CMAKE_CURRENT_BINARY_DIR}/auto_bp_peering_test_shape.json COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/split_blocklog_replay_test.py ${CMAKE_CURRENT_BINARY_DIR}/split_blocklog_replay_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/shard_register_test.py ${CMAKE_CURRENT_BINARY_DIR}/shard_register_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/xshard_transfer_test.py ${CMAKE_CURRENT_BINARY_DIR}/xshard_transfer_test.py COPYONLY)
 
 if(DEFINED ENV{GITHUB_ACTIONS})
   set(UNSHARE "--unshared")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/launcher.py ${CMAKE_CURRENT_BINARY_DI
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/auto_bp_peering_test.py ${CMAKE_CURRENT_BINARY_DIR}/auto_bp_peering_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/auto_bp_peering_test_shape.json ${CMAKE_CURRENT_BINARY_DIR}/auto_bp_peering_test_shape.json COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/split_blocklog_replay_test.py ${CMAKE_CURRENT_BINARY_DIR}/split_blocklog_replay_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/shard_register_test.py ${CMAKE_CURRENT_BINARY_DIR}/shard_register_test.py COPYONLY)
 
 if(DEFINED ENV{GITHUB_ACTIONS})
   set(UNSHARE "--unshared")

--- a/tests/TestHarness/WalletMgr.py
+++ b/tests/TestHarness/WalletMgr.py
@@ -15,6 +15,7 @@ class WalletMgr(object):
     __walletDataDir=f"{Utils.TestLogRoot}/test_wallet_0"
     __walletLogOutFile=f"{__walletDataDir}/test_keosd_out.log"
     __walletLogErrFile=f"{__walletDataDir}/test_keosd_err.log"
+    __walletPasswordFile=f"{__walletDataDir}/test_keosd_pass.txt"
     __MaxPort=9999
 
     # pylint: disable=too-many-arguments
@@ -154,6 +155,9 @@ class WalletMgr(object):
         p=m.group(1)
         wallet=Wallet(name, p, self.host, self.port)
         self.wallets[name] = wallet
+        with open(WalletMgr.__walletPasswordFile, 'w') as f:
+            f.write("%s=%s" % (name, p))
+            f.close()
 
         if accounts:
             self.importKeys(accounts,wallet)

--- a/tests/TestHarness/queries.py
+++ b/tests/TestHarness/queries.py
@@ -5,6 +5,7 @@ import json
 import re
 import subprocess
 import time
+import shlex
 
 import urllib.request
 import urllib.parse
@@ -168,7 +169,7 @@ class NodeosQueries:
         return balance
 
     @staticmethod
-    def currencyIntToStr(balance, symbol):
+    def currencyIntToStr(balance, symbol = CORE_SYMBOL):
         """Converts currency int of form 123456 to string "12.3456 SYS" where SYS is symbol string"""
         assert(isinstance(balance, int))
         assert(isinstance(symbol, str))
@@ -571,6 +572,51 @@ class NodeosQueries:
                 trans=Utils.runCmdReturnJson(cmd, silentErrors=silentErrors)
             elif returnType==ReturnType.raw:
                 trans=Utils.runCmdReturnStr(cmd)
+            else:
+                unhandledEnumType(returnType)
+
+            if Utils.Debug:
+                end=time.perf_counter()
+                Utils.Print("cmd Duration: %.3f sec" % (end-start))
+        except subprocess.CalledProcessError as ex:
+            if not silentErrors:
+                end=time.perf_counter()
+                out=ex.output.decode("utf-8")
+                msg=ex.stderr.decode("utf-8")
+                errorMsg="Exception during \"%s\". Exception message: %s.  stdout: %s.  cmd Duration=%.3f sec. %s" % (cmdDesc, msg, out, end-start, exitMsg)
+                if exitOnError:
+                    Utils.cmdError(errorMsg)
+                    Utils.errorExit(errorMsg)
+                else:
+                    Utils.Print("ERROR: %s" % (errorMsg))
+            return None
+
+        if exitOnError and trans is None:
+            Utils.cmdError("could not \"%s\". %s" % (cmdDesc,exitMsg))
+            Utils.errorExit("Failed to \"%s\"" % (cmdDesc))
+
+        return trans
+
+
+    def processCleosCmdArr(self, cmdArr, cmdDesc, silentErrors=True, exitOnError=False, exitMsg=None, returnType=ReturnType.json):
+        assert(isinstance(returnType, ReturnType))
+        assert(isinstance(cmdArr, list))
+        cmdArr = [Utils.EosClientPath] + shlex.split(self.eosClientArgs()) + cmdArr
+        if Utils.Debug: Utils.Print("cmd: %s" % (shlex.join(cmdArr)))
+        if exitMsg is not None:
+            exitMsg="Context: " + exitMsg
+        else:
+            exitMsg=""
+        trans=None
+        start=time.perf_counter()
+        try:
+            Utils.Print("returnType=%s" %(returnType))
+            if returnType==ReturnType.json:
+                Utils.Print("runCmdArrReturnJson11111")
+                trans=Utils.runCmdArrReturnJson(cmdArr, silentErrors=silentErrors)
+            elif returnType==ReturnType.raw:
+                Utils.Print("runCmdArrReturnJson111112")
+                trans=Utils.runCmdArrReturnStr(cmdArr)
             else:
                 unhandledEnumType(returnType)
 

--- a/tests/TestHarness/queries.py
+++ b/tests/TestHarness/queries.py
@@ -777,3 +777,19 @@ class NodeosQueries:
     def getActivatedProtocolFeatures(self):
         latestBlockHeaderState = self.getLatestBlockHeaderState()
         return latestBlockHeaderState["activated_protocol_features"]["protocol_features"]
+
+    def getShards(self, lower_bound, limit):
+        param = {
+            "lower_bound": lower_bound,
+            "limit": limit
+        }
+        res = self.processUrllibRequest("chain", "get_shards", param)
+        code = res["code"]
+        payload = res["payload"]
+        assert code == 200, f"ERROR: Invalid response code '{code}' of get_shards, payload:'{payload}'"
+        return payload
+
+    def isShardExists(self, name):
+        res = self.getShards(name, 1)
+        shards = res["shards"]
+        return shards and len(shards) > 0 and shards[0]["name"] == name

--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -69,6 +69,8 @@ class Utils:
     EosServerName="fonod"
     EosServerPath=str(testBinPath / EosServerName)
 
+    SysAccount="flon"
+
     ShuttingDown=False
 
     FileDivider="================================================================="

--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -70,6 +70,8 @@ class Utils:
     EosServerPath=str(testBinPath / EosServerName)
 
     SysAccount="flon"
+    SysTokenAccount="flon.token"
+    MainShardName="main"
 
     ShuttingDown=False
 
@@ -314,7 +316,7 @@ class Utils:
     @staticmethod
     def runCmdArrReturnJson(cmdArr, trace=False, silentErrors=True):
         retStr=Utils.checkOutput(cmdArr)
-        return Utils.toJson(retStr)
+        return Utils.toJson(retStr, trace)
 
     @staticmethod
     def runCmdReturnStr(cmd, trace=False):

--- a/tests/TestHarness/transactions.py
+++ b/tests/TestHarness/transactions.py
@@ -357,3 +357,14 @@ class Transactions(NodeosQueries):
         allBuiltinProtocolFeatureDigests = self.getAllBuiltinFeatureDigestsToPreactivate()
         self.preactivateProtocolFeatures(allBuiltinProtocolFeatureDigests)
 
+    # void regshard( const eosio::name& name, const eosio::name& owner, bool enabled );
+    def regshard(self, name, owner, enabled):
+        assert(isinstance(owner, Account))
+        Utils.Print("push regshard action with name:{}, owner:{}, enabled {}".format(name, owner.name, enabled))
+        data="{{\"name\":\"{}\", \"owner\":\"{}\", \"enabled\":1}}".format(name, owner.name, enabled)
+        opts="--permission {}@active".format(Utils.SysAccount)
+        success, trans=self.pushMessage(Utils.SysAccount, "regshard", data, opts)
+        if not success:
+            Utils.Print("ERROR: Failed to regshard name {}".format(name))
+            return None
+        self.waitForTransactionInBlock(trans['transaction_id'])

--- a/tests/shard_register_test.py
+++ b/tests/shard_register_test.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+
+import copy
+import time
+import json
+import os
+import signal
+import subprocess
+
+from TestHarness import Account, Cluster, TestHelper, Utils, WalletMgr, CORE_SYMBOL
+from TestHarness.Node import BlockType
+from TestHarness.TestHelper import AppArgs
+
+########################################################################
+# shard_register_test
+#
+#  register shards test
+#
+########################################################################
+
+Print=Utils.Print
+errorExit=Utils.errorExit
+
+appArgs=AppArgs()
+args = TestHelper.parse_args({"-n", "--dump-error-details","--keep-logs","-v","--leave-running","--clean-run","--unshared"})
+Utils.Debug=args.v
+pnodes=3
+totalNodes=args.n
+if totalNodes<=pnodes+2:
+    totalNodes=pnodes+2
+cluster=Cluster(walletd=True,unshared=args.unshared)
+dumpErrorDetails=args.dump_error_details
+keepLogs=args.keep_logs
+dontKill=args.leave_running
+prodCount=1
+killAll=args.clean_run
+walletPort=TestHelper.DEFAULT_WALLET_PORT
+
+walletMgr=WalletMgr(True, port=walletPort)
+testSuccessful=False
+killEosInstances=not dontKill
+killWallet=not dontKill
+
+WalletdName=Utils.EosWalletName
+# ClientName="focli"
+
+EOSIO_ACCT_PRIVATE_DEFAULT_KEY = "5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"
+EOSIO_ACCT_PUBLIC_DEFAULT_KEY = "FO6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"
+
+try:
+    TestHelper.printSystemInfo("BEGIN")
+    cluster.setWalletMgr(walletMgr)
+
+    cluster.killall(allInstances=killAll)
+    cluster.cleanup()
+    Print("Stand up cluster")
+    successDuration = 60
+    failure_duration = 40
+    extraNodeosArgs=" --transaction-finality-status-max-storage-size-gb 1 " + \
+                   f"--transaction-finality-status-success-duration-sec {successDuration} --transaction-finality-status-failure-duration-sec {failure_duration}"
+    extraNodeosArgs+=" --http-max-response-time-ms 990000"
+    if cluster.launch(prodCount=prodCount, onlyBios=False, pnodes=pnodes, totalNodes=totalNodes, totalProducers=pnodes*prodCount,
+                      topo="line", extraNodeosArgs=extraNodeosArgs) is False:
+        Utils.errorExit("Failed to stand up eos cluster.")
+
+    Print("Validating system accounts after bootstrap")
+    cluster.validateAccounts(None)
+
+    biosNode=cluster.biosNode
+    prod0=cluster.getNode(0)
+    prod1=cluster.getNode(1)
+    testNode=cluster.getNode(totalNodes-1)
+
+    Print("Kill the bios node")
+    biosNode.kill(signal.SIGTERM)
+
+    Print("Wait for node0's head block to become irreversible")
+    cluster.waitOnClusterSync()
+
+    Print("Creating account1")
+    account1 = Account('account1')
+    account1.ownerPublicKey = EOSIO_ACCT_PUBLIC_DEFAULT_KEY
+    account1.activePublicKey = EOSIO_ACCT_PUBLIC_DEFAULT_KEY
+    cluster.createAccountAndVerify(account1, cluster.eosioAccount, stakedDeposit=1000)
+
+    Print("Creating account2")
+    account2 = Account('account2')
+    account2.ownerPublicKey = EOSIO_ACCT_PUBLIC_DEFAULT_KEY
+    account2.activePublicKey = EOSIO_ACCT_PUBLIC_DEFAULT_KEY
+    cluster.createAccountAndVerify(account2, cluster.eosioAccount, stakedDeposit=1000)
+
+    Print("Validating accounts after bootstrap")
+    cluster.validateAccounts([account1, account2])
+
+    prod0Info=prod0.getInfo(exitOnError=True)
+    nodeInfo=testNode.getInfo(exitOnError=True)
+    # Print(f"prod0 info={json.dumps(prod0Info, indent=1)}")
+    # Print(f"test node info={json.dumps(nodeInfo, indent=1)}")
+
+    def getState(status):
+        assert status is not None, "ERROR: getTransactionStatus failed to return any status"
+        assert "state" in status, \
+            f"ERROR: getTransactionStatus returned a status object that didn't have a \"state\" field. state: {json.dumps(status, indent=1)}"
+        return status["state"]
+
+    def isState(state, expectedState, allowedState=None, notAllowedState=None):
+        if state == expectedState:
+            return True
+        assert allowedState is None or state == allowedState, \
+               f"ERROR: getTransactionStatus should have indicated a \"state\" of \"{expectedState}\" or \"{allowedState}\" but it was \"{state}\""
+        assert notAllowedState is None or state != notAllowedState, \
+               f"ERROR: getTransactionStatus should have indicated a \"state\" of \"{expectedState}\" and not \"{notAllowedState}\" but it was \"{state}\""
+        return False
+
+    localState = "LOCALLY_APPLIED"
+    inBlockState = "IN_BLOCK"
+    irreversibleState = "IRREVERSIBLE"
+    unknownState = "UNKNOWN"
+    status = []
+    state = None
+    i = 0
+    preInfo = None
+    postInfo = None
+    transferAmount=10
+
+    # Ensuring that prod0's producer is active, which will give more time to identify the transaction as "LOCALLY_APPLIED" before it travels
+    # through the chain of nodes to node0 to be added to a block. It is still possible to hit the end of a block and state be IN_BLOCK here.
+    # defproducera -> defproducerb -> defproducerc -> NPN
+    prod0.waitForProducer("defproducera", exitOnError=True)
+    testNode.regshard("shard1", account1, True)
+    transId=testNode.getLastTrackedTransactionId()
+    retStatus=testNode.getTransactionStatus(transId)
+    state = getState(retStatus)
+
+    assert (state == localState or state == inBlockState), \
+        f"ERROR: getTransactionStatus didn't return \"{localState}\" or \"{inBlockState}\" state.\n\nstatus: {json.dumps(retStatus, indent=1)}"
+    status.append(copy.copy(retStatus))
+    startingBlockNum=testNode.getInfo()["head_block_num"]
+
+    def validateTrxState(status, present):
+        bnPresent = "block_number" in status
+        biPresent = "block_id" in status
+        btPresent = "block_timestamp" in status
+        desc = "" if present else " not"
+        group = bnPresent and biPresent and btPresent if present else not bnPresent and not biPresent and not btPresent
+        assert group, \
+            f"ERROR: getTransactionStatus should{desc} contain \"block_number\", \"block_id\", or \"block_timestamp\" since state was \"{getState(status)}\".\nstatus: {json.dumps(status, indent=1)}"
+
+    present = True if state == inBlockState else False
+    validateTrxState(status[0], present)
+
+    def validate(status, knownTrx=True):
+        assert "head_number" in status and "head_id" in status and "head_timestamp" in status, \
+            f"ERROR: getTransactionStatus is missing \"head_number\", \"head_id\", and \"head_timestamp\".\nstatus: {json.dumps(status, indent=1)}"
+
+        assert "irreversible_number" in status and "irreversible_id" in status and "irreversible_timestamp" in status, \
+            f"ERROR: getTransactionStatus is missing \"irreversible_number\", \"irreversible_id\", and \"irreversible_timestamp\".\nstatus: {json.dumps(status, indent=1)}"
+
+        assert not knownTrx or "expiration" in status, \
+            f"ERROR: getTransactionStatus is missing \"expiration\".\nstatus: {json.dumps(status, indent=1)}"
+
+        assert "earliest_tracked_block_id" in status and "earliest_tracked_block_number" in status, \
+            f"ERROR: getTransactionStatus is missing \"earliest_tracked_block_id\" and \"earliest_tracked_block_number\".\nstatus: {json.dumps(status, indent=1)}"
+
+    validate(status[0])
+
+    # since the transaction is traveling opposite to the flow of blocks (prodNodes[0] then prodNodes[1] etc) once the flow of blocks has progressed to testNode's
+    # nearest neighbor, it will at least be in its block if not one of the earlier ones
+    testNode.waitForProducer("defproducerb")
+    testNode.waitForProducer("defproducerc")
+
+    status.append(testNode.getTransactionStatus(transId))
+    state = getState(status[1])
+    assert state == inBlockState, f"ERROR: getTransactionStatus never returned a \"{inBlockState}\" state"
+
+    validateTrxState(status[1], present=True)
+
+    validate(status[1])
+
+    assert status[0]["head_number"] < status[1]["head_number"], \
+        f"ERROR: Successive calls to getTransactionStatus should return increasing values for \"head_number\".\n1st status: {json.dumps(status[0], indent=1)}\n\n2nd status: {json.dumps(status[1], indent=1)}"
+
+    block_number = status[1]["block_number"]
+    assert testNode.waitForIrreversibleBlock(block_number, timeout=180), \
+        f"ERROR: Failed to advance irreversible block to {block_number}. \nAPI Node info: {json.dumps(prod0.getInfo(), indent=1)}\n\nProducer info: {json.dumps(testNode.getInfo(), indent=1)}"
+
+    retStatus=testNode.getTransactionStatus(transId)
+    state = getState(retStatus)
+    assert state == irreversibleState, \
+        f"ERROR: Successive calls to getTransactionStatus should have resulted in eventual \"{irreversibleState}\" state." + \
+        f"\n1st status: {json.dumps(status[0], indent=1)}\n\n2nd status: {json.dumps(status[1], indent=1)}" + \
+        f"\n\nfinal status: {json.dumps(retStatus, indent=1)}"
+    validate(retStatus)
+
+    leeway=4
+    assert testNode.waitForBlock(blockNum=startingBlockNum+(successDuration*2),timeout=successDuration+leeway)
+
+    recentBlockNum=testNode.getBlockNum()
+    retStatus=testNode.getTransactionStatus(transId)
+    state = getState(retStatus)
+    assert state == unknownState, \
+        f"ERROR: Calling getTransactionStatus after the success_duration should have resulted in an \"{irreversibleState}\" state.\nstatus: {json.dumps(retStatus, indent=1)}"
+    validateTrxState(retStatus, present=False)
+    validate(retStatus, knownTrx=False)
+    assert recentBlockNum <= retStatus["head_number"], \
+        "ERROR: Expected call to getTransactionStatus to return increasing values for \"head_number\" beyond previous known recent block number."
+
+    def waitForShardRegistered(name):
+        # default to the typical configuration of 21 producers, each producing 12 blocks in a row (every 1/2 second)
+        timeout = 21 * 6
+        start=time.perf_counter()
+        startingBlockNum=testNode.getInfo()["head_block_num"]
+        def isShardRegistered():
+            return testNode.isShardExists(name)
+        found = Utils.waitForBool(isShardRegistered, timeout)
+        assert found, \
+            f"Waited for {time.perf_counter()-start} sec but never found shard: {name}. Started with block num {startingBlockNum} and ended with {self.getInfo()['head_block_num']}"
+        return found
+
+    waitForShardRegistered("shard1")
+    testSuccessful=True
+
+finally:
+    TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killWallet, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
+
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/xshard_transfer_test.py
+++ b/tests/xshard_transfer_test.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+import copy
+import time
+import json
+import os
+import signal
+import subprocess
+
+from TestHarness import Account, Cluster, TestHelper, Utils, WalletMgr, CORE_SYMBOL
+from TestHarness.Node import BlockType
+from TestHarness.TestHelper import AppArgs
+
+########################################################################
+# shard_register_test
+#
+#  register shards test
+#
+########################################################################
+
+Print=Utils.Print
+errorExit=Utils.errorExit
+
+appArgs=AppArgs()
+args = TestHelper.parse_args({"-n", "--dump-error-details","--keep-logs","-v","--leave-running","--clean-run","--unshared"})
+Utils.Debug=args.v
+pnodes=3
+totalNodes=args.n
+if totalNodes<=pnodes+2:
+    totalNodes=pnodes+2
+cluster=Cluster(walletd=True,unshared=args.unshared)
+dumpErrorDetails=args.dump_error_details
+keepLogs=args.keep_logs
+dontKill=args.leave_running
+prodCount=1
+killAll=args.clean_run
+walletPort=TestHelper.DEFAULT_WALLET_PORT
+
+walletMgr=WalletMgr(True, port=walletPort)
+testSuccessful=False
+killEosInstances=not dontKill
+killWallet=not dontKill
+
+WalletdName=Utils.EosWalletName
+# ClientName="focli"
+
+EOSIO_ACCT_PRIVATE_DEFAULT_KEY = "5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"
+EOSIO_ACCT_PUBLIC_DEFAULT_KEY = "FO6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"
+
+try:
+    TestHelper.printSystemInfo("BEGIN")
+    cluster.setWalletMgr(walletMgr)
+
+    cluster.killall(allInstances=killAll)
+    cluster.cleanup()
+    Print("Stand up cluster")
+    successDuration = 60
+    failure_duration = 40
+    extraNodeosArgs=" --transaction-finality-status-max-storage-size-gb 1 " + \
+                   f"--transaction-finality-status-success-duration-sec {successDuration} --transaction-finality-status-failure-duration-sec {failure_duration}"
+    extraNodeosArgs+=" --http-max-response-time-ms 990000"
+    if cluster.launch(prodCount=prodCount, onlyBios=False, pnodes=pnodes, totalNodes=totalNodes, totalProducers=pnodes*prodCount,
+                      topo="line", extraNodeosArgs=extraNodeosArgs) is False:
+        Utils.errorExit("Failed to stand up eos cluster.")
+
+    Print("Validating system accounts after bootstrap")
+    cluster.validateAccounts(None)
+
+    biosNode=cluster.biosNode
+    prod0=cluster.getNode(0)
+    prod1=cluster.getNode(1)
+    testNode=cluster.getNode(totalNodes-1)
+
+    Print("Kill the bios node")
+    biosNode.kill(signal.SIGTERM)
+
+    Print("Wait for node0's head block to become irreversible")
+    cluster.waitOnClusterSync()
+
+    Print("Creating account1")
+    account1 = Account('account1')
+    account1.ownerPublicKey = EOSIO_ACCT_PUBLIC_DEFAULT_KEY
+    account1.activePublicKey = EOSIO_ACCT_PUBLIC_DEFAULT_KEY
+    cluster.createAccountAndVerify(account1, cluster.eosioAccount, stakedDeposit=1000)
+
+    Print("Creating account2")
+    account2 = Account('account2')
+    account2.ownerPublicKey = EOSIO_ACCT_PUBLIC_DEFAULT_KEY
+    account2.activePublicKey = EOSIO_ACCT_PUBLIC_DEFAULT_KEY
+    cluster.createAccountAndVerify(account2, cluster.eosioAccount, stakedDeposit=1000)
+
+    Print("Validating accounts after bootstrap")
+    cluster.validateAccounts([account1, account2])
+
+    transferAmountStr = testNode.currencyIntToStr(100, CORE_SYMBOL)
+    testNode.transferFunds(cluster.eosioAccount, account1, transferAmountStr, "initial fund")
+    if Utils.Debug: Utils.Print("Initial funds of account %s transfered on transaction id %s." % (account1, testNode.getLastTrackedTransactionId()))
+
+    testNode.regshard("shard1", account1, True, waitForTransBlock=True)
+    if Utils.Debug: Utils.Print("Register shard '%s' on transaction id %s." % ("shard1", testNode.getLastTrackedTransactionId()))
+
+    startingBlockNum = testNode.getInfo()["head_block_num"]
+
+    def waitForShardRegistered(name):
+        # default to the typical configuration of 21 producers, each producing 12 blocks in a row (every 1/2 second)
+        timeout = 21 * 6 * 2
+        start=time.perf_counter()
+        startingBlockNum=testNode.getInfo()["head_block_num"]
+        def isShardRegistered():
+            return testNode.isShardExists(name)
+        found = Utils.waitForBool(isShardRegistered, timeout)
+        assert found, \
+            f"Waited for {time.perf_counter()-start} sec but never found shard: {name}. Started with block num {startingBlockNum} and ended with {testNode.getInfo()['head_block_num']}"
+        return found
+
+    waitForShardRegistered("shard1")
+
+    testNode.xTransferOut(account1, Utils.MainShardName, "shard1", Utils.SysTokenAccount, testNode.currencyIntToStr(10), waitForTransBlock=True)
+
+    testSuccessful=True
+
+finally:
+    TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killWallet, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
+
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/unittests/contracts/eosio.system/include/eosio.system/native.hpp
+++ b/unittests/contracts/eosio.system/include/eosio.system/native.hpp
@@ -120,16 +120,7 @@ namespace eosiosystem {
       EOSLIB_SERIALIZE( abi_hash, (owner)(hash) )
    };
 
-   /**
-    * xtoken is the struct of `xtransfer` action type of xshard.
-    */
-   struct [[eosio::action]] xtoken {
-      eosio::asset      quantity;
-      std::string       memo;
 
-      // explicit serialization macro is not necessary, used here only to improve compilation time
-      EOSLIB_SERIALIZE( xtoken, (quantity)(memo) )
-   };
 
    void check_auth_change(name contract, name account, const binary_extension<name>& authorized_by);
 
@@ -319,20 +310,32 @@ namespace eosiosystem {
          [[eosio::action]]
          void setcode( const name& account, uint8_t vmtype, uint8_t vmversion, const std::vector<char>& code,
                        const binary_extension<std::string>& memo ) {}
+
+         /**
+          * xtransfer is the struct of `xtransfer` action type of xshard.
+          */
+         struct [[eosio::action]] xtransfer {
+            eosio::asset      quantity;
+            std::string       memo;
+
+            // explicit serialization macro is not necessary, used here only to improve compilation time
+            EOSLIB_SERIALIZE( xtransfer, (quantity)(memo) )
+         };
+
          /**
           * Allows `owner` account to make a request to transfer tokens from current shard to `to_shard`.
           *
           * @param owner - the owner account to execute this action,
           * @param to_shard - the shard to be transferred to,
           * @param contract - the token contract,
-          * @param action_type - the action type: `xtoken`.
+          * @param action_type - the action type: `xtransfer`.
           * @param action_data - the action data
           */
          [[eosio::action]]
          void xshout(   name                 owner,
                         name                 to_shard,
                         name                 contract,
-                        name                 action_name,
+                        name                 action_type,
                         std::vector<char>    action_data );
 
          /**

--- a/unittests/contracts/eosio.system/src/shard.cpp
+++ b/unittests/contracts/eosio.system/src/shard.cpp
@@ -14,14 +14,14 @@ void native::xshout( name                 owner,
 {
    require_auth(owner);
    // check(is_shard(to_shard), "to_shard is not a valid shard");
-   if (action_type == "xtoken"_n) {
+   if (action_type == "xtransfer"_n) {
       std::vector<permission_level> perms = {
             { owner, system_contract::active_permission },
             { _self, system_contract::active_permission }
       };
       eosio::token::xshout_action xshout_act{ contract, std::move(perms) };
 
-      auto x = eosio::unpack<xtoken>(action_data);
+      auto x = eosio::unpack<xtransfer>(action_data);
       xshout_act.send( owner, to_shard, x.quantity, x.memo );
    } else {
       check(false, "unsupported action type");
@@ -36,13 +36,13 @@ void native::xshin( const name& owner, const checksum256& xsh_id ) {
 
    check(owner == xsh.owner, "owner mismatch");
 
-   if (xsh.action_type == "xtoken"_n) {
+   if (xsh.action_type == "xtransfer"_n) {
       std::vector<permission_level> perms = {
             { owner, system_contract::active_permission },
             { _self, system_contract::active_permission }
       };
       eosio::token::xshin_action xshin_act{ xsh.contract, std::move(perms) };
-      auto x = eosio::unpack<xtoken>(xsh.action_data);
+      auto x = eosio::unpack<xtransfer>(xsh.action_data);
       xshin_act.send( owner, xsh.from_shard, x.quantity, x.memo );
    } else {
       check(false, "unsupported action type");

--- a/unittests/xshard_tests.cpp
+++ b/unittests/xshard_tests.cpp
@@ -18,11 +18,11 @@
 #include <eosio/chain/global_property_object.hpp>
 #include <eosio/chain/generated_transaction_object.hpp>
 
-struct xtoken {
+struct xtransfer {
    asset             quantity;
    std::string       memo;
 };
-FC_REFLECT( xtoken, (quantity)(memo) )
+FC_REFLECT( xtransfer, (quantity)(memo) )
 
 class xshard_tester : public eosio_system::eosio_system_tester {
 public:
@@ -69,14 +69,14 @@ public:
    transaction_trace_ptr xshout( const name&                owner,
                                  const name&                to_shard,
                                  const name&                contract,
-                                 const name&                action_name,
+                                 const name&                action_type,
                                  const std::vector<char>&   action_data )
    {
       return push_action( config::system_account_name, "xshout"_n, owner, mvo()
             ( "owner",            owner )
             ( "to_shard",         to_shard )
             ( "contract",         contract )
-            ( "action_name",      action_name )
+            ( "action_type",      action_type )
             ( "action_data",      action_data )
       );
    }
@@ -135,8 +135,8 @@ BOOST_FIXTURE_TEST_CASE( xshard_transfer_test, xshard_tester ) try {
 
    if (!shard1_db) BOOST_ERROR("shard1 db not found");
    transfer(config::system_account_name, "alice1111111"_n, core_from_string("100.0000"));
-   auto xshout_data = fc::raw::pack( xtoken{core_from_string("1.0000"), ""} );
-   auto xshout_trx = xshout( "alice1111111"_n, shard1_name, "flon.token"_n, "xtoken"_n, xshout_data );
+   auto xshout_data = fc::raw::pack( xtransfer{core_from_string("1.0000"), ""} );
+   auto xshout_trx = xshout( "alice1111111"_n, shard1_name, "flon.token"_n, "xtransfer"_n, xshout_data );
    BOOST_REQUIRE_EQUAL(get_balance(main_db, "alice1111111"_n), core_from_string("99.0000"));
 
    const auto& xsh_indx = shared_db.get_index<xshard_index, by_id>();
@@ -155,7 +155,7 @@ BOOST_FIXTURE_TEST_CASE( xshard_transfer_test, xshard_tester ) try {
    BOOST_REQUIRE_EQUAL(xsh_itr->from_shard, config::main_shard_name);
    BOOST_REQUIRE_EQUAL(xsh_itr->to_shard, shard1_name);
    BOOST_REQUIRE_EQUAL(xsh_itr->contract, "flon.token"_n);
-   BOOST_REQUIRE_EQUAL(xsh_itr->action_type, "xtoken"_n);
+   BOOST_REQUIRE_EQUAL(xsh_itr->action_type, "xtransfer"_n);
    BOOST_REQUIRE(bytes(xsh_itr->action_data.begin(), xsh_itr->action_data.end())  == xshout_data);
    auto scheduled_xshin_trx = xsh_itr->scheduled_xshin_trx;
    BOOST_REQUIRE(scheduled_xshin_trx != transaction_id_type());
@@ -188,11 +188,11 @@ BOOST_FIXTURE_TEST_CASE( xshard_transfer_test, xshard_tester ) try {
    BOOST_REQUIRE_EQUAL(gen_trx_indx.size(), 0);
    BOOST_REQUIRE(gen_trx_indx.find(scheduled_xshin_trx) == gen_trx_indx.end());
 
-   auto xshout_data2 = fc::raw::pack( xtoken{core_from_string("1.0000"), ""} );
+   auto xshout_data2 = fc::raw::pack( xtransfer{core_from_string("1.0000"), ""} );
 
    transfer(config::system_account_name, "bob111111111"_n, core_from_string("100.0000"));
 
-   auto xshout_trx2 = xshout( "bob111111111"_n, shard1_name, "flon.token"_n, "xtoken"_n, xshout_data2 );
+   auto xshout_trx2 = xshout( "bob111111111"_n, shard1_name, "flon.token"_n, "xtransfer"_n, xshout_data2 );
    BOOST_REQUIRE_EQUAL(get_balance(main_db, "bob111111111"_n), core_from_string("99.0000"));
 
    auto xsh_id2 = xshard_object::make_xsh_id(xshout_trx2->id, 0);
@@ -210,7 +210,7 @@ BOOST_FIXTURE_TEST_CASE( xshard_transfer_test, xshard_tester ) try {
    BOOST_REQUIRE_EQUAL(xsh_itr2->from_shard, config::main_shard_name);
    BOOST_REQUIRE_EQUAL(xsh_itr2->to_shard, shard1_name);
    BOOST_REQUIRE_EQUAL(xsh_itr2->contract, "flon.token"_n);
-   BOOST_REQUIRE_EQUAL(xsh_itr2->action_type, "xtoken"_n);
+   BOOST_REQUIRE_EQUAL(xsh_itr2->action_type, "xtransfer"_n);
    BOOST_REQUIRE(bytes(xsh_itr2->action_data.begin(), xsh_itr2->action_data.end())  == xshout_data2);
    auto scheduled_xshin_trx2 = xsh_itr2->scheduled_xshin_trx;
    BOOST_REQUIRE(scheduled_xshin_trx2 != transaction_id_type());


### PR DESCRIPTION
1. Add registering shard test.
2. Add `xtransfer` test.
3. Add `get_shards` rpc api.
4. Improve `xtransfer` protocol (transfer token between shards).
5. Add the `xtransfer` sub command of `system` command to focli.